### PR TITLE
feat: v0.5.2 — Claude Code skill + install-skill CLI

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -337,6 +337,37 @@ VideoToolbox는 런타임에 자동 감지되며, 사용 불가 시 `libx264`로
 
 [PROMPTS.md](./PROMPTS.md)에 바로 사용할 수 있는 AI 프롬프트 템플릿이 있습니다. ChatGPT나 Claude에 복붙하고 내 사이트 URL만 넣으면 YAML 시나리오를 생성해줍니다.
 
+## Claude Code 스킬
+
+Clipwise에는 [Claude Code](https://claude.com/claude-code) 스킬이 내장되어 있습니다. 설치 후 Claude Code에서 `/clipwise`를 입력하면 자연어로 YAML 시나리오 생성, 검증, 녹화까지 한 번에 할 수 있습니다.
+
+### 스킬 설치
+
+```bash
+npx clipwise install-skill
+```
+
+`.claude/skills/clipwise.md`에 스킬 파일이 복사됩니다 (`.claude/` 디렉토리가 있으면 프로젝트 레벨, 없으면 `~/.claude/skills/`에 설치).
+
+### 사용법
+
+Claude Code 세션에서:
+
+```
+/clipwise
+> http://localhost:3000 대시보드 데모 녹화해줘
+  — 로그인 버튼 클릭, 이메일/비밀번호 입력, 분석 페이지 이동
+```
+
+Claude가 자동으로:
+1. `clipwise.yaml` 시나리오 생성
+2. `npx clipwise validate`로 검증
+3. `npx clipwise record`로 MP4 녹화
+
+### 업데이트
+
+clipwise 업그레이드 후 `npx clipwise install-skill`을 다시 실행하면 최신 스킬로 업데이트됩니다.
+
 ## GitHub Pages
 
 `docs/` 폴더에 문서 사이트와 라이브 데모 대시보드가 포함되어 있습니다:

--- a/README.md
+++ b/README.md
@@ -421,6 +421,37 @@ npx clipwise record my-scenario.yaml -f mp4 -o ./output
 
 See [PROMPTS.md](./PROMPTS.md) for a ready-to-use prompt template. Copy-paste it to ChatGPT or Claude with your site URL, and get a working YAML scenario back.
 
+## Claude Code Skill
+
+Clipwise ships a built-in [Claude Code](https://claude.com/claude-code) skill. Once installed, type `/clipwise` in Claude Code to generate YAML scenarios, validate, and record — all through natural language.
+
+### Install the skill
+
+```bash
+npx clipwise install-skill
+```
+
+This copies the skill file to `.claude/skills/clipwise.md` (project-level if `.claude/` exists, otherwise `~/.claude/skills/`).
+
+### Usage
+
+In any Claude Code session:
+
+```
+/clipwise
+> Record a demo of my dashboard at http://localhost:3000
+  — click the login button, type credentials, navigate to analytics
+```
+
+Claude will:
+1. Generate a complete `clipwise.yaml` scenario
+2. Run `npx clipwise validate` to check for errors
+3. Run `npx clipwise record` to produce the MP4
+
+### Update
+
+Re-run `npx clipwise install-skill` after upgrading clipwise to get the latest skill.
+
 ## GitHub Pages
 
 Clipwise includes a documentation site and a live demo dashboard in the `docs/` folder. To host it:

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
     <a href="#quickstart" class="nav-link">Quick Start</a>
     <a href="#effects" class="nav-link">Effects</a>
     <a href="#ai-schema" class="nav-link">AI-Ready</a>
+    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="./demo/" class="nav-link">Demo</a>
     <div class="nav-lang">
       <span class="lang-btn active">EN</span>
@@ -438,6 +439,51 @@ effects:
 # - waitForResponse: set up before triggering action (auto-handled)
 # - Timing: captureDelay 50-100ms, holdDuration 500-800ms for snappy demos</code></pre>
   </div>
+</section>
+
+<!-- Claude Code Skill -->
+<section class="section" id="claude-code">
+  <div class="section-label">Claude Code</div>
+  <h2 class="section-title">AI-powered workflow</h2>
+  <p class="section-sub">Install the built-in <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> skill and generate scenarios with natural language. One command to install, one slash command to use.</p>
+
+  <div class="steps-list">
+    <div class="step-item">
+      <div class="step-num">1</div>
+      <div class="step-content">
+        <div class="step-title">Install the skill</div>
+        <div class="step-desc">Copies the Clipwise skill to your <code>.claude/skills/</code> directory. Run once per project (or globally).</div>
+        <div class="code-block">
+          <div class="code-header">bash</div>
+          <pre><code>npx clipwise install-skill</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">2</div>
+      <div class="step-content">
+        <div class="step-title">Use in Claude Code</div>
+        <div class="step-desc">Type <code>/clipwise</code> in any Claude Code session. Describe what you want to record in plain language.</div>
+        <div class="code-block">
+          <div class="code-header">Claude Code</div>
+          <pre><code>/clipwise
+> Record a demo of my dashboard at http://localhost:3000
+  — click login, type credentials, navigate to analytics</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">3</div>
+      <div class="step-content">
+        <div class="step-title">Claude handles the rest</div>
+        <div class="step-desc">Claude generates a complete YAML scenario, validates it with <code>npx clipwise validate</code>, then records the MP4 — all automatically.</div>
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top:20px;font-size:14px;color:var(--muted);">After upgrading clipwise, re-run <code>npx clipwise install-skill</code> to get the latest skill.</p>
 </section>
 
 <!-- Effects -->

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -18,6 +18,7 @@
     <a href="#quickstart" class="nav-link">빠른 시작</a>
     <a href="#effects" class="nav-link">이펙트</a>
     <a href="#ai-schema" class="nav-link">AI-Ready</a>
+    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="../demo/" class="nav-link">데모</a>
     <div class="nav-lang">
       <a href="../" class="lang-btn">EN</a>
@@ -436,6 +437,51 @@ effects:
 # - waitForResponse: 트리거 액션 전에 자동으로 리스너 등록됨
 # - 타이밍: captureDelay 50-100ms, holdDuration 500-800ms (빠른 데모)</code></pre>
   </div>
+</section>
+
+<!-- Claude Code 스킬 -->
+<section class="section" id="claude-code">
+  <div class="section-label">Claude Code</div>
+  <h2 class="section-title">AI 기반 워크플로</h2>
+  <p class="section-sub">내장된 <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> 스킬을 설치하면 자연어로 시나리오를 생성할 수 있습니다. 설치 한 번, 슬래시 커맨드 한 번이면 끝.</p>
+
+  <div class="steps-list">
+    <div class="step-item">
+      <div class="step-num">1</div>
+      <div class="step-content">
+        <div class="step-title">스킬 설치</div>
+        <div class="step-desc">Clipwise 스킬을 <code>.claude/skills/</code> 디렉토리에 복사합니다. 프로젝트당 한 번(또는 글로벌) 실행.</div>
+        <div class="code-block">
+          <div class="code-header">bash</div>
+          <pre><code>npx clipwise install-skill</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">2</div>
+      <div class="step-content">
+        <div class="step-title">Claude Code에서 사용</div>
+        <div class="step-desc">Claude Code 세션에서 <code>/clipwise</code>를 입력하세요. 녹화할 내용을 자연어로 설명하면 됩니다.</div>
+        <div class="code-block">
+          <div class="code-header">Claude Code</div>
+          <pre><code>/clipwise
+> http://localhost:3000 대시보드 데모 녹화해줘
+  — 로그인 클릭, 이메일/비밀번호 입력, 분석 페이지 이동</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">3</div>
+      <div class="step-content">
+        <div class="step-title">나머지는 Claude가 처리</div>
+        <div class="step-desc">Claude가 YAML 시나리오를 생성하고, <code>npx clipwise validate</code>로 검증한 후, MP4를 녹화합니다 — 전부 자동.</div>
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top:20px;font-size:14px;color:var(--muted);">clipwise 업그레이드 후 <code>npx clipwise install-skill</code>을 다시 실행하면 최신 스킬로 업데이트됩니다.</p>
 </section>
 
 <!-- Effects -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipwise",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Scriptable cinematic screen recorder for product demos — YAML in, polished MP4 out",
   "type": "module",
   "main": "dist/index.js",
@@ -10,6 +10,7 @@
   },
   "files": [
     "dist",
+    "skills",
     "README.md",
     "LICENSE"
   ],

--- a/skills/clipwise.md
+++ b/skills/clipwise.md
@@ -1,0 +1,373 @@
+# Clipwise — Cinematic Screen Recorder
+
+You are an expert at creating Clipwise YAML scenarios. Clipwise is a Playwright + CDP-based scriptable screen recorder that turns YAML scenarios into polished MP4/GIF demo videos with cinematic effects (zoom, cursor trail, device frame, keystroke HUD, etc.).
+
+TRIGGER: when the user wants to record a demo video, create a screen recording scenario, generate a product demo, or mentions "clipwise".
+
+## Setup Check
+
+Before creating a scenario, verify clipwise is installed:
+
+```bash
+npx clipwise --version
+```
+
+If not installed:
+```bash
+npm install -D clipwise
+```
+
+ffmpeg is required for MP4 output:
+```bash
+# macOS
+brew install ffmpeg
+# Ubuntu
+sudo apt install ffmpeg
+```
+
+## YAML Schema Reference
+
+### Top-Level Structure
+
+```yaml
+name: string              # Scenario name (required)
+description: string       # Optional description
+
+viewport:
+  width: 1280             # Browser width (100-3840, default: 1280)
+  height: 800             # Browser height (100-3840, default: 800)
+
+effects:                  # All optional, sensible defaults
+  zoom: ...
+  cursor: ...
+  background: ...
+  deviceFrame: ...
+  keystroke: ...
+  watermark: ...
+  speedRamp: ...
+
+output:
+  format: mp4             # mp4 | gif | png-sequence
+  width: 1280             # Output width
+  height: 800             # Output height
+  fps: 30                 # 1-60
+  preset: balanced        # social | balanced | archive
+  outputDir: "./output"
+  filename: "my-recording"
+
+steps: []                 # Array of steps (min 1, first must have navigate)
+```
+
+### Step Structure
+
+```yaml
+- name: "Step name"           # Optional label
+  captureDelay: 50            # ms to wait after actions before capturing (50-100 for snappy)
+  holdDuration: 700           # ms to hold on result (500-800 for snappy)
+  transition: none            # none | fade
+  actions: []                 # Array of actions
+```
+
+### Actions (12 types)
+
+#### Basic Actions
+
+1. **navigate** — Open a URL (MUST be the first action in step 1)
+```yaml
+- action: navigate
+  url: "https://example.com"
+  waitUntil: load             # load | domcontentloaded | networkidle (default)
+```
+
+2. **click** — Click an element
+```yaml
+- action: click
+  selector: "#my-button"
+  delay: 0                    # Optional click delay (ms)
+  timeout: 15000              # Optional element wait timeout
+```
+
+3. **type** — Type text character-by-character (auto-focuses the element)
+```yaml
+- action: type
+  selector: "#email-input"
+  text: "user@example.com"
+  delay: 18                   # ms per character (15-25 recommended, default: 50)
+  timeout: 15000              # Optional
+```
+
+4. **hover** — Hover over an element
+```yaml
+- action: hover
+  selector: ".card"
+  timeout: 15000              # Optional
+```
+
+5. **scroll** — Scroll the page
+```yaml
+- action: scroll
+  y: 400                      # Vertical px (positive=down, negative=up)
+  x: 0                        # Horizontal px
+  selector: ".container"      # Optional: scroll within element
+  smooth: true                # Default: true
+  timeout: 15000              # Optional
+```
+
+6. **wait** — Pause for a fixed duration
+```yaml
+- action: wait
+  duration: 1000              # ms
+```
+
+7. **screenshot** — Capture marker (for png-sequence)
+```yaml
+- action: screenshot
+  name: "result"              # Optional label
+  fullPage: false             # Default: false
+```
+
+#### Async Wait Actions (for dynamic/API content)
+
+8. **waitForSelector** — Wait for element state
+```yaml
+- action: waitForSelector
+  selector: ".result-panel"
+  state: visible              # visible (default) | attached | hidden
+  timeout: 15000
+```
+
+9. **waitForNavigation** — Wait for page load
+```yaml
+- action: waitForNavigation
+  waitUntil: networkidle      # load | domcontentloaded | networkidle
+  timeout: 15000
+```
+
+10. **waitForURL** — Wait for URL match
+```yaml
+- action: waitForURL
+  url: "https://example.com/dashboard"
+  timeout: 15000
+```
+
+11. **waitForFunction** — Wait for JS expression to be truthy
+```yaml
+- action: waitForFunction
+  expression: "document.querySelector('.done') !== null"
+  polling: raf                # raf (default) | number in ms (e.g. 500)
+  timeout: 30000
+```
+
+12. **waitForResponse** — Wait for network response (URL substring match)
+```yaml
+- action: waitForResponse
+  url: "/api/chat/completions"
+  status: 200                 # Optional HTTP status filter
+  timeout: 30000
+```
+
+### Effects Configuration
+
+#### Zoom — Adaptive zoom follows cursor on clicks
+```yaml
+zoom:
+  enabled: true
+  intensity: moderate         # subtle(1.15x) | light(1.25x) | moderate(1.35x) | strong(1.5x) | dramatic(1.8x)
+  # scale: 1.35              # Or use numeric value (overridden by intensity)
+  duration: 500               # Zoom animation ms
+  easing: ease-in-out         # ease-in-out | ease-in | ease-out | linear
+  autoZoom:
+    followCursor: true
+    transitionDuration: 300
+    padding: 200
+```
+
+#### Cursor — Custom cursor with click effect, trail, highlight
+```yaml
+cursor:
+  enabled: true
+  size: 20
+  color: "#000000"
+  speed: fast                 # fast (~72ms) | normal (~144ms) | slow (~288ms)
+  smoothing: true
+  clickEffect: true
+  clickColor: "rgba(59, 130, 246, 0.3)"
+  clickRadius: 30
+  trail: true
+  trailLength: 8
+  trailColor: "rgba(59, 130, 246, 0.2)"
+  highlight: true
+  highlightRadius: 40
+  highlightColor: "rgba(255, 215, 0, 0.18)"
+```
+
+#### Background — Gradient/solid padding with corners and shadow
+```yaml
+background:
+  type: gradient              # gradient | solid | image
+  value: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+  padding: 48
+  borderRadius: 14
+  shadow: true
+```
+
+#### Device Frame — Wraps recording in a device mockup
+```yaml
+deviceFrame:
+  enabled: true
+  type: browser               # browser | macbook | iphone | ipad | android | none
+  darkMode: true
+```
+
+| Type | Description |
+|------|-------------|
+| browser | macOS browser chrome with traffic lights |
+| macbook | MacBook Pro frame |
+| iphone | iPhone 15 Pro with Dynamic Island |
+| ipad | iPad Pro with camera dot |
+| android | Android with punch-hole camera |
+
+#### Keystroke HUD — Shows typed keys on screen
+```yaml
+keystroke:
+  enabled: true
+  showTyping: false           # true = show regular typing; false = shortcuts only (industry default)
+  position: bottom-center     # bottom-center | bottom-left | bottom-right
+  fontSize: 16
+  backgroundColor: "rgba(0, 0, 0, 0.75)"
+  textColor: "#ffffff"
+  padding: 8
+  fadeAfter: 1500
+```
+
+#### Watermark — Text overlay at corner
+```yaml
+watermark:
+  enabled: true
+  text: "My App"
+  position: bottom-right      # top-left | top-right | bottom-left | bottom-right
+  opacity: 0.5
+  fontSize: 14
+  color: "#ffffff"
+```
+
+#### Speed Ramp — Auto-adjusts speed near actions
+```yaml
+speedRamp:
+  enabled: true
+  idleSpeed: 3.0              # Skip factor for idle frames (0.5-8)
+  actionSpeed: 0.8            # Slow factor near clicks (0.25-2)
+  transitionFrames: 15
+```
+
+### Output Presets
+
+| Preset | Use case | Approx size (30s) |
+|--------|----------|--------------------|
+| social | Twitter, LinkedIn, Loom | ~2-4 MB |
+| balanced | General purpose, portfolio | ~4-6 MB |
+| archive | High-fidelity storage | larger |
+
+## Critical Rules
+
+1. **First step MUST contain a `navigate` action** — the browser needs a page to start
+2. **Selectors**: use CSS selectors (`#id`, `.class`, `[data-testid="..."]`). No control chars, semicolons, backticks, or backslashes
+3. **Type needs focus**: the `type` action auto-focuses, but the element must exist and be visible
+4. **Scroll before interact**: if an element is below the fold, `scroll` to it first
+5. **Prefer async waits over fixed `wait`**: use `waitForSelector`, `waitForFunction`, `waitForResponse` instead of guessing durations
+6. **Viewport = output**: if viewport and output dimensions differ, output will be scaled (a warning is shown)
+7. **Mobile scenarios**: use `viewport: {width: 390, height: 844}` with `deviceFrame.type: iphone` and `output: {width: 540, height: 1080}`
+
+## Timing Presets
+
+### Snappy demo (~30s)
+- `captureDelay: 50-100`
+- `holdDuration: 500-800`
+- `type.delay: 15-25`
+
+### Cinematic demo (~60s)
+- `captureDelay: 200-400`
+- `holdDuration: 1500-2500`
+- `type.delay: 40-60`
+
+## CLI Commands
+
+```bash
+# Record from YAML scenario
+npx clipwise record <scenario.yaml> -f mp4 -o ./output
+
+# Instant demo with built-in dashboard
+npx clipwise demo
+npx clipwise demo --device iphone
+npx clipwise demo --url https://my-app.com
+
+# Create template YAML
+npx clipwise init
+
+# Validate scenario without recording
+npx clipwise validate <scenario.yaml>
+```
+
+## Workflow
+
+1. Ask the user for: target URL, what actions to demo, and preferred style (snappy/cinematic)
+2. Generate a complete `clipwise.yaml` scenario
+3. Run `npx clipwise validate clipwise.yaml` to check for errors
+4. If valid, run `npx clipwise record clipwise.yaml -f mp4 -o ./output`
+5. If the user has specific selectors, use them. Otherwise suggest inspecting the page first
+
+## Selector Discovery
+
+If the user doesn't know selectors, help them find them:
+```bash
+# Open the target URL in a browser and inspect elements
+npx playwright open <url>
+```
+
+Or read the page HTML to find appropriate selectors:
+```bash
+curl -s <url> | head -200
+```
+
+## Example: Minimal Scenario
+
+```yaml
+name: "My App Demo"
+viewport:
+  width: 1280
+  height: 800
+
+effects:
+  deviceFrame:
+    enabled: true
+    type: browser
+  cursor:
+    enabled: true
+    clickEffect: true
+    highlight: true
+  background:
+    padding: 48
+    borderRadius: 14
+    shadow: true
+
+output:
+  format: mp4
+  fps: 30
+  preset: balanced
+
+steps:
+  - name: "Open app"
+    captureDelay: 100
+    holdDuration: 1000
+    actions:
+      - action: navigate
+        url: "http://localhost:3000"
+        waitUntil: load
+
+  - name: "Click CTA"
+    captureDelay: 50
+    holdDuration: 800
+    actions:
+      - action: click
+        selector: "#cta-button"
+```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,9 +9,10 @@ import { CanvasRenderer } from "../compose/canvas-renderer.js";
 import { encodeGif, encodeMp4Stream, savePngSequence } from "../compose/video-encoder.js";
 import { StreamingSession, ConcurrentSession } from "../compose/streaming-session.js";
 import type { PipelineProgress } from "../compose/streaming-session.js";
-import { writeFile, mkdir, access } from "fs/promises";
+import { writeFile, mkdir, access, copyFile, readFile } from "fs/promises";
 import { join, resolve, dirname } from "path";
-import { pathToFileURL } from "url";
+import { pathToFileURL, fileURLToPath } from "url";
+import { homedir } from "os";
 
 const program = new Command();
 
@@ -495,6 +496,68 @@ program
       spinner.fail("Demo recording failed");
       const message = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`\nError: ${message}`));
+      process.exit(1);
+    }
+  });
+
+program
+  .command("install-skill")
+  .description("Install the Clipwise skill for Claude Code")
+  .action(async () => {
+    try {
+      // Locate the skill source file bundled with clipwise
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+      const skillSource = resolve(__dirname, "..", "..", "skills", "clipwise.md");
+
+      // Verify the skill file exists in the package
+      try {
+        await access(skillSource);
+      } catch {
+        console.error(chalk.red("Error: Skill file not found in clipwise package."));
+        console.error(chalk.yellow("This may happen if you're running from source. Try: npm rebuild clipwise"));
+        process.exit(1);
+      }
+
+      // Determine target directory: project-level .claude/skills/ first, fallback to global
+      const projectSkillDir = resolve(".claude", "skills");
+      const globalSkillDir = join(homedir(), ".claude", "skills");
+
+      // Prefer project-level if .claude/ directory already exists in cwd
+      let targetDir: string;
+      try {
+        await access(resolve(".claude"));
+        targetDir = projectSkillDir;
+      } catch {
+        targetDir = globalSkillDir;
+      }
+
+      await mkdir(targetDir, { recursive: true });
+      const targetPath = join(targetDir, "clipwise.md");
+
+      // Check if already installed and up-to-date
+      try {
+        const existing = await readFile(targetPath, "utf-8");
+        const incoming = await readFile(skillSource, "utf-8");
+        if (existing === incoming) {
+          console.log(chalk.green("Clipwise skill is already up to date."));
+          console.log(`  Location: ${chalk.bold(targetPath)}`);
+          console.log(`\nUse ${chalk.bold("/clipwise")} in Claude Code to get started.`);
+          return;
+        }
+      } catch {
+        // File doesn't exist yet, proceed with install
+      }
+
+      await copyFile(skillSource, targetPath);
+
+      console.log(chalk.green("Clipwise skill installed successfully!"));
+      console.log(`  Location: ${chalk.bold(targetPath)}`);
+      console.log(`\nUsage in Claude Code:`);
+      console.log(`  ${chalk.bold("/clipwise")} — Generate YAML scenarios, validate, and record demos`);
+      console.log(`\nTo update the skill later, run this command again.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(chalk.red(`Failed to install skill: ${message}`));
       process.exit(1);
     }
   });


### PR DESCRIPTION
## Summary
- **Claude Code 스킬 추가**: `skills/clipwise.md` — 12종 액션, 이펙트 설정, 워크플로우 전체 레퍼런스를 포함한 스킬 파일
- **`install-skill` CLI 커맨드**: `npx clipwise install-skill`로 `.claude/skills/`에 원클릭 설치 (프로젝트/글로벌 자동 판단, 멱등성 보장)
- **문서 반영**: README (EN/KO), 정적 페이지 (docs/ EN/KO) 모두 Claude Code 섹션 + 네비게이션 링크 추가
- **버전**: 0.5.1 → 0.5.2

## User Flow
```bash
npm install -D clipwise          # 설치
npx clipwise install-skill       # 스킬 등록
# Claude Code에서 /clipwise → 자연어로 시나리오 생성 → validate → record
```

## Test plan
- [x] `npm run build` — 빌드 성공
- [x] `npm run typecheck` — 타입 체크 통과
- [x] `npm test` — 76개 테스트 통과
- [x] `npx clipwise install-skill` — 스킬 파일 정상 복사 확인
- [x] 중복 실행 시 "already up to date" 출력 확인
- [ ] PR 머지 후 `git tag v0.5.2 && git push --tags` → npm 자동 배포

## npm 배포
머지 후 태그 push로 자동 배포:
```bash
git tag v0.5.2
git push --tags
```

Generated with [Claude Code](https://claude.com/claude-code)