### PR TITLE
docs: align Skill, static pages with v0.6.0 features

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -80,6 +80,37 @@ const frames = await renderer.composeAll(session.frames);
 const mp4 = await encodeMp4(frames, scenario.output);
 ```
 
+## Claude Code 스킬
+
+Clipwise에는 [Claude Code](https://claude.com/claude-code) 스킬이 내장되어 있습니다. 설치 후 Claude Code에서 `/clipwise`를 입력하면 자연어로 YAML 시나리오 생성, 검증, 녹화까지 한 번에 할 수 있습니다.
+
+### 스킬 설치
+
+```bash
+npx clipwise install-skill
+```
+
+`.claude/skills/clipwise.md`에 스킬 파일이 복사됩니다 (`.claude/` 디렉토리가 있으면 프로젝트 레벨, 없으면 `~/.claude/skills/`에 설치).
+
+### 사용법
+
+Claude Code 세션에서:
+
+```
+/clipwise
+> http://localhost:3000 대시보드 데모 녹화해줘
+  — 로그인 버튼 클릭, 이메일/비밀번호 입력, 분석 페이지 이동
+```
+
+Claude가 자동으로:
+1. `clipwise.yaml` 시나리오 생성
+2. `npx clipwise validate`로 검증
+3. `npx clipwise record`로 MP4 녹화
+
+### 업데이트
+
+clipwise 업그레이드 후 `npx clipwise install-skill`을 다시 실행하면 최신 스킬로 업데이트됩니다.
+
 ## YAML 시나리오 형식
 
 시나리오는 4개 섹션으로 구성됩니다: 메타데이터, 이펙트, 출력, 스텝.
@@ -402,37 +433,6 @@ VideoToolbox는 런타임에 자동 감지되며, 사용 불가 시 `libx264`로
 ## AI로 시나리오 작성
 
 [PROMPTS.md](./PROMPTS.md)에 바로 사용할 수 있는 AI 프롬프트 템플릿이 있습니다. ChatGPT나 Claude에 복붙하고 내 사이트 URL만 넣으면 YAML 시나리오를 생성해줍니다.
-
-## Claude Code 스킬
-
-Clipwise에는 [Claude Code](https://claude.com/claude-code) 스킬이 내장되어 있습니다. 설치 후 Claude Code에서 `/clipwise`를 입력하면 자연어로 YAML 시나리오 생성, 검증, 녹화까지 한 번에 할 수 있습니다.
-
-### 스킬 설치
-
-```bash
-npx clipwise install-skill
-```
-
-`.claude/skills/clipwise.md`에 스킬 파일이 복사됩니다 (`.claude/` 디렉토리가 있으면 프로젝트 레벨, 없으면 `~/.claude/skills/`에 설치).
-
-### 사용법
-
-Claude Code 세션에서:
-
-```
-/clipwise
-> http://localhost:3000 대시보드 데모 녹화해줘
-  — 로그인 버튼 클릭, 이메일/비밀번호 입력, 분석 페이지 이동
-```
-
-Claude가 자동으로:
-1. `clipwise.yaml` 시나리오 생성
-2. `npx clipwise validate`로 검증
-3. `npx clipwise record`로 MP4 녹화
-
-### 업데이트
-
-clipwise 업그레이드 후 `npx clipwise install-skill`을 다시 실행하면 최신 스킬로 업데이트됩니다.
 
 ## GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,37 @@ const frames = await renderer.composeAll(session.frames);
 const mp4 = await encodeMp4(frames, scenario.output);
 ```
 
+## Claude Code Skill
+
+Clipwise ships a built-in [Claude Code](https://claude.com/claude-code) skill. Once installed, type `/clipwise` in Claude Code to generate YAML scenarios, validate, and record — all through natural language.
+
+### Install the skill
+
+```bash
+npx clipwise install-skill
+```
+
+This copies the skill file to `.claude/skills/clipwise.md` (project-level if `.claude/` exists, otherwise `~/.claude/skills/`).
+
+### Usage
+
+In any Claude Code session:
+
+```
+/clipwise
+> Record a demo of my dashboard at http://localhost:3000
+  — click the login button, type credentials, navigate to analytics
+```
+
+Claude will:
+1. Generate a complete `clipwise.yaml` scenario
+2. Run `npx clipwise validate` to check for errors
+3. Run `npx clipwise record` to produce the MP4
+
+### Update
+
+Re-run `npx clipwise install-skill` after upgrading clipwise to get the latest skill.
+
 ## YAML Scenario Format
 
 A scenario has 4 sections: metadata, effects, output, and steps.
@@ -482,37 +513,6 @@ npx clipwise record my-scenario.yaml -f mp4 -o ./output
 ### Writing Scenarios with AI
 
 See [PROMPTS.md](./PROMPTS.md) for a ready-to-use prompt template. Copy-paste it to ChatGPT or Claude with your site URL, and get a working YAML scenario back.
-
-## Claude Code Skill
-
-Clipwise ships a built-in [Claude Code](https://claude.com/claude-code) skill. Once installed, type `/clipwise` in Claude Code to generate YAML scenarios, validate, and record — all through natural language.
-
-### Install the skill
-
-```bash
-npx clipwise install-skill
-```
-
-This copies the skill file to `.claude/skills/clipwise.md` (project-level if `.claude/` exists, otherwise `~/.claude/skills/`).
-
-### Usage
-
-In any Claude Code session:
-
-```
-/clipwise
-> Record a demo of my dashboard at http://localhost:3000
-  — click the login button, type credentials, navigate to analytics
-```
-
-Claude will:
-1. Generate a complete `clipwise.yaml` scenario
-2. Run `npx clipwise validate` to check for errors
-3. Run `npx clipwise record` to produce the MP4
-
-### Update
-
-Re-run `npx clipwise install-skill` after upgrading clipwise to get the latest skill.
 
 ## GitHub Pages
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,9 +16,9 @@
   <div class="nav-links">
     <a href="#features" class="nav-link">Features</a>
     <a href="#quickstart" class="nav-link">Quick Start</a>
+    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="#effects" class="nav-link">Effects</a>
     <a href="#ai-schema" class="nav-link">AI-Ready</a>
-    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="./demo/" class="nav-link">Demo</a>
     <div class="nav-lang">
       <span class="lang-btn active">EN</span>
@@ -174,6 +174,146 @@ const session  = await recorder.record(scenario);
 const renderer = new CanvasRenderer(scenario.effects, scenario.output, scenario.steps);
 const frames   = await renderer.composeAll(session.frames);
 const mp4      = await encodeMp4(frames, scenario.output);</code></pre>
+  </div>
+</section>
+
+<!-- Claude Code Skill -->
+<section class="section" id="claude-code">
+  <div class="section-label">Claude Code</div>
+  <h2 class="section-title">AI-powered workflow</h2>
+  <p class="section-sub">Install the built-in <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> skill and generate scenarios with natural language. One command to install, one slash command to use.</p>
+
+  <div class="steps-list">
+    <div class="step-item">
+      <div class="step-num">1</div>
+      <div class="step-content">
+        <div class="step-title">Install the skill</div>
+        <div class="step-desc">Copies the Clipwise skill to your <code>.claude/skills/</code> directory. Run once per project (or globally).</div>
+        <div class="code-block">
+          <div class="code-header">bash</div>
+          <pre><code>npx clipwise install-skill</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">2</div>
+      <div class="step-content">
+        <div class="step-title">Use in Claude Code</div>
+        <div class="step-desc">Type <code>/clipwise</code> in any Claude Code session. Describe what you want to record in plain language.</div>
+        <div class="code-block">
+          <div class="code-header">Claude Code</div>
+          <pre><code>/clipwise
+> Record a demo of my dashboard at http://localhost:3000
+  — click login, type credentials, navigate to analytics</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">3</div>
+      <div class="step-content">
+        <div class="step-title">Claude handles the rest</div>
+        <div class="step-desc">Claude generates a complete YAML scenario, validates it with <code>npx clipwise validate</code>, then records the MP4 — all automatically.</div>
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top:20px;font-size:14px;color:var(--muted);">After upgrading clipwise, re-run <code>npx clipwise install-skill</code> to get the latest skill.</p>
+</section>
+
+<!-- Effects -->
+<section class="section" id="effects">
+  <div class="section-label">Effects</div>
+  <h2 class="section-title">Cinematic effects</h2>
+  <p class="section-sub">All effects are optional with sensible defaults. Mix and match for your style.</p>
+
+  <div class="effects-grid">
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Zoom</div>
+      <div class="effect-desc">Adaptive zoom follows the cursor and zooms in on click targets automatically. Smart camera: auto-suppressed during scroll, focal point follows cursor position. Use intensity presets (subtle → dramatic) or set a numeric scale.</div>
+      <span class="effect-tag">followCursor</span>
+      <span class="effect-tag">intensity</span>
+      <span class="effect-tag">smart camera</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>zoom:
+  enabled: true
+  intensity: light   # subtle|light|moderate|strong|dramatic
+  duration: 800</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Cursor</div>
+      <div class="effect-desc">Custom cursor with click ripple, trail, glow highlight, and speed control.</div>
+      <span class="effect-tag">trail</span>
+      <span class="effect-tag">highlight</span>
+      <span class="effect-tag">clickEffect</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>cursor:
+  enabled: true
+  speed: "normal"
+  trail: true
+  highlight: true</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Background</div>
+      <div class="effect-desc">Gradient or solid padding with rounded corners and drop shadow.</div>
+      <span class="effect-tag">gradient</span>
+      <span class="effect-tag">shadow</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>background:
+  type: gradient
+  value: "linear-gradient(135deg,
+    #667eea 0%, #764ba2 100%)"
+  padding: 48
+  borderRadius: 14</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Device Frame</div>
+      <div class="effect-desc">Wrap recordings in a device mockup — browser, iPhone, iPad, or Android.</div>
+      <span class="effect-tag">browser</span>
+      <span class="effect-tag">iphone</span>
+      <span class="effect-tag">android</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>deviceFrame:
+  enabled: true
+  type: browser   # or iphone/ipad/android
+  darkMode: true</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Keystroke HUD</div>
+      <div class="effect-desc">Shows what was typed at the bottom of the screen. Multi-session: each input field gets its own line (up to 3, oldest dimmed). Off by default — set <code>showTyping: true</code> to enable.</div>
+      <span class="effect-tag">bottom-center</span>
+      <span class="effect-tag">multi-session</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>keystroke:
+  enabled: true
+  showTyping: true   # default: false
+  position: bottom-center
+  fontSize: 16
+  fadeAfter: 1500</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>Speed Ramp</div>
+      <div class="effect-desc">Slows down near clicks and speeds up idle sections automatically.</div>
+      <span class="effect-tag">idleSpeed</span>
+      <span class="effect-tag">actionSpeed</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>speedRamp:
+  enabled: true
+  idleSpeed: 3.0
+  actionSpeed: 0.8</code></pre>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -455,146 +595,6 @@ effects:
 # - Smart camera: zoom suppressed during scroll; followCursor pans to cursor
 # - Transitions: fade/blur for cinematic cuts; slide-left/up for sequences
 # - Audio: only works with MP4 format; file must exist at specified path</code></pre>
-  </div>
-</section>
-
-<!-- Claude Code Skill -->
-<section class="section" id="claude-code">
-  <div class="section-label">Claude Code</div>
-  <h2 class="section-title">AI-powered workflow</h2>
-  <p class="section-sub">Install the built-in <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> skill and generate scenarios with natural language. One command to install, one slash command to use.</p>
-
-  <div class="steps-list">
-    <div class="step-item">
-      <div class="step-num">1</div>
-      <div class="step-content">
-        <div class="step-title">Install the skill</div>
-        <div class="step-desc">Copies the Clipwise skill to your <code>.claude/skills/</code> directory. Run once per project (or globally).</div>
-        <div class="code-block">
-          <div class="code-header">bash</div>
-          <pre><code>npx clipwise install-skill</code></pre>
-        </div>
-      </div>
-    </div>
-
-    <div class="step-item">
-      <div class="step-num">2</div>
-      <div class="step-content">
-        <div class="step-title">Use in Claude Code</div>
-        <div class="step-desc">Type <code>/clipwise</code> in any Claude Code session. Describe what you want to record in plain language.</div>
-        <div class="code-block">
-          <div class="code-header">Claude Code</div>
-          <pre><code>/clipwise
-> Record a demo of my dashboard at http://localhost:3000
-  — click login, type credentials, navigate to analytics</code></pre>
-        </div>
-      </div>
-    </div>
-
-    <div class="step-item">
-      <div class="step-num">3</div>
-      <div class="step-content">
-        <div class="step-title">Claude handles the rest</div>
-        <div class="step-desc">Claude generates a complete YAML scenario, validates it with <code>npx clipwise validate</code>, then records the MP4 — all automatically.</div>
-      </div>
-    </div>
-  </div>
-
-  <p style="margin-top:20px;font-size:14px;color:var(--muted);">After upgrading clipwise, re-run <code>npx clipwise install-skill</code> to get the latest skill.</p>
-</section>
-
-<!-- Effects -->
-<section class="section" id="effects">
-  <div class="section-label">Effects</div>
-  <h2 class="section-title">Cinematic effects</h2>
-  <p class="section-sub">All effects are optional with sensible defaults. Mix and match for your style.</p>
-
-  <div class="effects-grid">
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Zoom</div>
-      <div class="effect-desc">Adaptive zoom follows the cursor and zooms in on click targets automatically. Smart camera: auto-suppressed during scroll, focal point follows cursor position. Use intensity presets (subtle → dramatic) or set a numeric scale.</div>
-      <span class="effect-tag">followCursor</span>
-      <span class="effect-tag">intensity</span>
-      <span class="effect-tag">smart camera</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>zoom:
-  enabled: true
-  intensity: light   # subtle|light|moderate|strong|dramatic
-  duration: 800</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Cursor</div>
-      <div class="effect-desc">Custom cursor with click ripple, trail, glow highlight, and speed control.</div>
-      <span class="effect-tag">trail</span>
-      <span class="effect-tag">highlight</span>
-      <span class="effect-tag">clickEffect</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>cursor:
-  enabled: true
-  speed: "normal"
-  trail: true
-  highlight: true</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Background</div>
-      <div class="effect-desc">Gradient or solid padding with rounded corners and drop shadow.</div>
-      <span class="effect-tag">gradient</span>
-      <span class="effect-tag">shadow</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>background:
-  type: gradient
-  value: "linear-gradient(135deg,
-    #667eea 0%, #764ba2 100%)"
-  padding: 48
-  borderRadius: 14</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Device Frame</div>
-      <div class="effect-desc">Wrap recordings in a device mockup — browser, iPhone, iPad, or Android.</div>
-      <span class="effect-tag">browser</span>
-      <span class="effect-tag">iphone</span>
-      <span class="effect-tag">android</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>deviceFrame:
-  enabled: true
-  type: browser   # or iphone/ipad/android
-  darkMode: true</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Keystroke HUD</div>
-      <div class="effect-desc">Shows what was typed at the bottom of the screen. Multi-session: each input field gets its own line (up to 3, oldest dimmed). Off by default — set <code>showTyping: true</code> to enable.</div>
-      <span class="effect-tag">bottom-center</span>
-      <span class="effect-tag">multi-session</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>keystroke:
-  enabled: true
-  showTyping: true   # default: false
-  position: bottom-center
-  fontSize: 16
-  fadeAfter: 1500</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>Speed Ramp</div>
-      <div class="effect-desc">Slows down near clicks and speeds up idle sections automatically.</div>
-      <span class="effect-tag">idleSpeed</span>
-      <span class="effect-tag">actionSpeed</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>speedRamp:
-  enabled: true
-  idleSpeed: 3.0
-  actionSpeed: 0.8</code></pre>
-      </div>
-    </div>
   </div>
 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,10 @@ steps:
         url: "https://example.com"
     captureDelay: 200       # ms to wait after actions
     holdDuration: 800       # ms to hold on result
-    transition: none        # none | fade</code></pre>
+    transition: none        # none | fade | slide-left | slide-up | blur
+    effects:                # Per-step effects override (optional)
+      zoom:
+        enabled: false      # Disable zoom for this step only</code></pre>
   </div>
 
   <h3 class="action-group-title">Basic Actions</h3>
@@ -295,7 +298,7 @@ steps:
 
   <div class="code-block">
     <div class="code-header">yaml — Clipwise Full Schema Reference</div>
-    <pre><code id="ai-schema-content"># Clipwise YAML Schema Reference (v0.5.0)
+    <pre><code id="ai-schema-content"># Clipwise YAML Schema Reference (v0.6.0)
 # Scriptable cinematic screen recorder — YAML in, MP4 out
 # Install: npm install -D clipwise
 # Record:  npx clipwise record scenario.yaml -f mp4
@@ -312,16 +315,25 @@ output:
   format: mp4                    # mp4 | gif | png-sequence
   fps: 30                        # 1-60 (default: 30)
   preset: balanced               # social | balanced | archive (default: balanced)
-  # quality: 80                  # DEPRECATED — use preset instead
   width: 1280                    # default: 1280
   height: 800                    # default: 800
+
+# ─── Audio (MP4 only) ────────────────────────────────
+audio:
+  file: "./narration.mp3"        # MP3, WAV, etc.
+  volume: 1.0                    # 0.0 - 2.0 (default: 1.0)
+  fadeIn: 0                      # seconds (default: 0)
+  fadeOut: 0                     # seconds (default: 0)
 
 # ─── Steps ────────────────────────────────────────────
 steps:
   - name: "Step Name"            # optional
     captureDelay: 200            # ms after actions (default: 300)
     holdDuration: 800            # ms to hold result (default: 1500)
-    transition: none             # none | fade (default: none)
+    transition: none             # none | fade | slide-left | slide-up | blur
+    effects:                     # per-step override (optional, inherits global)
+      zoom:
+        enabled: false           # disable zoom for this step only
     actions:
       # --- Basic Actions (7) ---
       - action: navigate
@@ -385,29 +397,30 @@ steps:
 effects:
   zoom:
     enabled: true                # default: true
-    intensity: moderate          # subtle(1.15x)|light(1.25x)|moderate(1.35x)|strong(1.5x)|dramatic(1.8x)
-    # scale: 1.35               # numeric override (1-5); ignored when intensity is set
-    duration: 600                # ms (default: 600)
+    intensity: light             # subtle(1.15x)|light(1.25x)|moderate(1.35x)|strong(1.5x)|dramatic(1.8x)
+    # scale: 1.25               # numeric override (1-5); ignored when intensity is set
+    duration: 800                # ms (default: 800)
     autoZoom:
-      followCursor: true         # default: true
-      transitionDuration: 300    # ms (default: 400)
+      followCursor: true         # viewport pans to follow cursor position
+      transitionDuration: 300    # ms (default: 300)
       padding: 200               # px (default: 200)
+    # Smart camera: zoom auto-suppressed during scroll actions
   cursor:
     enabled: true                # default: true
     size: 20                     # px (default: 20)
     color: "#000000"             # default: #000000
-    speed: fast                  # fast | normal | slow (default: fast)
+    speed: normal                # fast (~72ms) | normal (~144ms) | slow (~288ms)
     clickEffect: true            # default: true
     clickColor: "rgba(59,130,246,0.3)"
-    trail: false                 # default: false
-    trailLength: 8               # default: 8
-    highlight: false             # default: false
-    highlightRadius: 40          # default: 40
+    trail: true                  # default: true
+    trailLength: 6               # default: 6
+    highlight: true              # default: true
+    highlightRadius: 35          # default: 35
   background:
     type: gradient               # gradient | solid | image (default: gradient)
     value: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
-    padding: 60                  # px (default: 60)
-    borderRadius: 12             # px (default: 12)
+    padding: 48                  # px (default: 48)
+    borderRadius: 14             # px (default: 14)
     shadow: true                 # default: true
   deviceFrame:
     enabled: false               # default: false
@@ -417,11 +430,11 @@ effects:
     enabled: false               # default: false
     showTyping: false            # show typed text (default: false — shortcuts only)
     position: bottom-center      # bottom-center | bottom-left | bottom-right
-    fontSize: 18                 # default: 18
+    fontSize: 16                 # default: 16
     fadeAfter: 1500              # ms (default: 1500)
   speedRamp:
     enabled: false               # default: false
-    idleSpeed: 3.0               # default: 3.0
+    idleSpeed: 2.0               # default: 2.0
     actionSpeed: 0.8             # default: 0.8
   watermark:
     enabled: false               # default: false
@@ -437,7 +450,11 @@ effects:
 # - Prefer async wait actions over fixed wait for reliability
 # - waitForFunction: use for AI streaming, dynamic content, DOM changes
 # - waitForResponse: set up before triggering action (auto-handled)
-# - Timing: captureDelay 50-100ms, holdDuration 500-800ms for snappy demos</code></pre>
+# - Timing: captureDelay 50-100ms, holdDuration 500-800ms for snappy demos
+# - Per-step effects: override any effect per step; unset props inherit global
+# - Smart camera: zoom suppressed during scroll; followCursor pans to cursor
+# - Transitions: fade/blur for cinematic cuts; slide-left/up for sequences
+# - Audio: only works with MP4 format; file must exist at specified path</code></pre>
   </div>
 </section>
 
@@ -495,15 +512,15 @@ effects:
   <div class="effects-grid">
     <div class="effect-card">
       <div class="effect-title"><span class="effect-dot"></span>Zoom</div>
-      <div class="effect-desc">Adaptive zoom follows the cursor and zooms in on click targets automatically. Use intensity presets (subtle → dramatic) or set a numeric scale.</div>
+      <div class="effect-desc">Adaptive zoom follows the cursor and zooms in on click targets automatically. Smart camera: auto-suppressed during scroll, focal point follows cursor position. Use intensity presets (subtle → dramatic) or set a numeric scale.</div>
       <span class="effect-tag">followCursor</span>
       <span class="effect-tag">intensity</span>
-      <span class="effect-tag">autoZoom</span>
+      <span class="effect-tag">smart camera</span>
       <div class="code-block" style="margin-top:10px;">
         <pre><code>zoom:
   enabled: true
-  intensity: moderate  # subtle|light|moderate|strong|dramatic
-  duration: 500</code></pre>
+  intensity: light   # subtle|light|moderate|strong|dramatic
+  duration: 800</code></pre>
       </div>
     </div>
 
@@ -516,7 +533,7 @@ effects:
       <div class="code-block" style="margin-top:10px;">
         <pre><code>cursor:
   enabled: true
-  speed: "fast"
+  speed: "normal"
   trail: true
   highlight: true</code></pre>
       </div>

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -209,7 +209,10 @@ steps:
         url: "https://example.com"
     captureDelay: 200       # 액션 후 대기(ms)
     holdDuration: 800       # 결과 화면 유지(ms)
-    transition: none        # none | fade</code></pre>
+    transition: none        # none | fade | slide-left | slide-up | blur
+    effects:                # 스텝별 이펙트 오버라이드 (선택)
+      zoom:
+        enabled: false      # 이 스텝에서만 줌 비활성화</code></pre>
   </div>
 
   <h3 class="action-group-title">기본 액션</h3>
@@ -295,7 +298,7 @@ steps:
 
   <div class="code-block">
     <div class="code-header">yaml — Clipwise 전체 스키마 레퍼런스</div>
-    <pre><code id="ai-schema-content"># Clipwise YAML Schema Reference (v0.5.0)
+    <pre><code id="ai-schema-content"># Clipwise YAML Schema Reference (v0.6.0)
 # 스크립터블 시네마틱 스크린 레코더 — YAML 작성, MP4 출력
 # 설치: npm install -D clipwise
 # 녹화: npx clipwise record scenario.yaml -f mp4
@@ -312,16 +315,25 @@ output:
   format: mp4                    # mp4 | gif | png-sequence
   fps: 30                        # 1-60 (기본: 30)
   preset: balanced               # social | balanced | archive (기본: balanced)
-  # quality: 80                  # 사용 중단 — preset 사용 권장
   width: 1280                    # 기본: 1280
   height: 800                    # 기본: 800
+
+# ─── 오디오 (MP4 전용) ───────────────────────────────
+audio:
+  file: "./narration.mp3"        # MP3, WAV 등
+  volume: 1.0                    # 0.0 - 2.0 (기본: 1.0)
+  fadeIn: 0                      # 초 (기본: 0)
+  fadeOut: 0                     # 초 (기본: 0)
 
 # ─── 스텝 ─────────────────────────────────────────────
 steps:
   - name: "스텝 이름"            # 선택
     captureDelay: 200            # 액션 후 대기 ms (기본: 300)
     holdDuration: 800            # 결과 화면 유지 ms (기본: 1500)
-    transition: none             # none | fade (기본: none)
+    transition: none             # none | fade | slide-left | slide-up | blur
+    effects:                     # 스텝별 오버라이드 (선택, 글로벌 상속)
+      zoom:
+        enabled: false           # 이 스텝에서만 줌 비활성화
     actions:
       # --- 기본 액션 (7종) ---
       - action: navigate
@@ -385,28 +397,30 @@ steps:
 effects:
   zoom:
     enabled: true                # 기본: true
-    scale: 1.8                   # 1-5 (기본: 1.8)
-    duration: 600                # ms (기본: 600)
+    intensity: light             # subtle(1.15x)|light(1.25x)|moderate(1.35x)|strong(1.5x)|dramatic(1.8x)
+    # scale: 1.25               # 숫자 오버라이드 (1-5); intensity 설정 시 무시
+    duration: 800                # ms (기본: 800)
     autoZoom:
-      followCursor: true         # 기본: true
-      maxScale: 2.0              # 기본: 2.0
+      followCursor: true         # 커서 위치를 따라 뷰포트 패닝
+      transitionDuration: 300    # ms (기본: 300)
       padding: 200               # px (기본: 200)
+    # 스마트 카메라: 스크롤 중 줌 자동 억제
   cursor:
     enabled: true                # 기본: true
     size: 20                     # px (기본: 20)
     color: "#000000"             # 기본: #000000
-    speed: fast                  # fast | normal | slow (기본: fast)
+    speed: normal                # fast (~72ms) | normal (~144ms) | slow (~288ms)
     clickEffect: true            # 기본: true
     clickColor: "rgba(59,130,246,0.3)"
-    trail: false                 # 기본: false
-    trailLength: 8               # 기본: 8
-    highlight: false             # 기본: false
-    highlightRadius: 40          # 기본: 40
+    trail: true                  # 기본: true
+    trailLength: 6               # 기본: 6
+    highlight: true              # 기본: true
+    highlightRadius: 35          # 기본: 35
   background:
     type: gradient               # gradient | solid | image (기본: gradient)
     value: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
-    padding: 60                  # px (기본: 60)
-    borderRadius: 12             # px (기본: 12)
+    padding: 48                  # px (기본: 48)
+    borderRadius: 14             # px (기본: 14)
     shadow: true                 # 기본: true
   deviceFrame:
     enabled: false               # 기본: false
@@ -414,12 +428,13 @@ effects:
     darkMode: false              # 기본: false
   keystroke:
     enabled: false               # 기본: false
+    showTyping: false            # 타이핑 표시 (기본: false — 단축키만)
     position: bottom-center      # bottom-center | bottom-left | bottom-right
-    fontSize: 18                 # 기본: 18
+    fontSize: 16                 # 기본: 16
     fadeAfter: 1500              # ms (기본: 1500)
   speedRamp:
     enabled: false               # 기본: false
-    idleSpeed: 3.0               # 기본: 3.0
+    idleSpeed: 2.0               # 기본: 2.0
     actionSpeed: 0.8             # 기본: 0.8
   watermark:
     enabled: false               # 기본: false
@@ -435,7 +450,11 @@ effects:
 # - 고정 wait보다 비동기 대기 액션 우선 사용 (더 안정적)
 # - waitForFunction: AI 스트리밍, 동적 콘텐츠, DOM 변화 감지
 # - waitForResponse: 트리거 액션 전에 자동으로 리스너 등록됨
-# - 타이밍: captureDelay 50-100ms, holdDuration 500-800ms (빠른 데모)</code></pre>
+# - 타이밍: captureDelay 50-100ms, holdDuration 500-800ms (빠른 데모)
+# - 스텝별 이펙트: 글로벌 이펙트를 스텝 단위로 오버라이드 가능
+# - 스마트 카메라: 스크롤 중 줌 억제; followCursor로 커서 추적
+# - 트랜지션: fade/blur는 시네마틱 컷, slide-left/up은 순차 흐름에 적합
+# - 오디오: MP4 포맷에서만 작동; 파일 경로가 유효해야 함</code></pre>
   </div>
 </section>
 
@@ -493,14 +512,15 @@ effects:
   <div class="effects-grid">
     <div class="effect-card">
       <div class="effect-title"><span class="effect-dot"></span>줌</div>
-      <div class="effect-desc">커서를 따라가며 클릭 대상에 자동으로 줌인합니다.</div>
+      <div class="effect-desc">커서를 따라가며 클릭 대상에 자동으로 줌인합니다. 스마트 카메라: 스크롤 중 줌 자동 억제, 커서 위치 추적. 강도 프리셋(subtle → dramatic) 또는 숫자 스케일 설정.</div>
       <span class="effect-tag">followCursor</span>
-      <span class="effect-tag">autoZoom</span>
+      <span class="effect-tag">intensity</span>
+      <span class="effect-tag">smart camera</span>
       <div class="code-block" style="margin-top:10px;">
         <pre><code>zoom:
   enabled: true
-  scale: 1.8
-  duration: 500</code></pre>
+  intensity: light   # subtle|light|moderate|strong|dramatic
+  duration: 800</code></pre>
       </div>
     </div>
 
@@ -513,7 +533,7 @@ effects:
       <div class="code-block" style="margin-top:10px;">
         <pre><code>cursor:
   enabled: true
-  speed: "fast"
+  speed: "normal"
   trail: true
   highlight: true</code></pre>
       </div>
@@ -550,11 +570,13 @@ effects:
 
     <div class="effect-card">
       <div class="effect-title"><span class="effect-dot"></span>키스트로크 HUD</div>
-      <div class="effect-desc">타이핑 내용을 화면 하단에 실시간으로 표시합니다.</div>
+      <div class="effect-desc">타이핑 내용을 화면 하단에 실시간으로 표시합니다. 멀티세션: 각 입력 필드가 별도 줄로 표시 (최대 3줄, 오래된 줄은 흐리게). 기본은 단축키만 — <code>showTyping: true</code>로 일반 타이핑도 표시.</div>
       <span class="effect-tag">bottom-center</span>
+      <span class="effect-tag">multi-session</span>
       <div class="code-block" style="margin-top:10px;">
         <pre><code>keystroke:
   enabled: true
+  showTyping: true   # 기본: false
   position: bottom-center
   fontSize: 16
   fadeAfter: 1500</code></pre>

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -16,9 +16,9 @@
   <div class="nav-links">
     <a href="#features" class="nav-link">기능</a>
     <a href="#quickstart" class="nav-link">빠른 시작</a>
+    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="#effects" class="nav-link">이펙트</a>
     <a href="#ai-schema" class="nav-link">AI-Ready</a>
-    <a href="#claude-code" class="nav-link">Claude Code</a>
     <a href="../demo/" class="nav-link">데모</a>
     <div class="nav-lang">
       <a href="../" class="lang-btn">EN</a>
@@ -174,6 +174,146 @@ const session  = await recorder.record(scenario);
 const renderer = new CanvasRenderer(scenario.effects, scenario.output, scenario.steps);
 const frames   = await renderer.composeAll(session.frames);
 const mp4      = await encodeMp4(frames, scenario.output);</code></pre>
+  </div>
+</section>
+
+<!-- Claude Code 스킬 -->
+<section class="section" id="claude-code">
+  <div class="section-label">Claude Code</div>
+  <h2 class="section-title">AI 기반 워크플로</h2>
+  <p class="section-sub">내장된 <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> 스킬을 설치하면 자연어로 시나리오를 생성할 수 있습니다. 설치 한 번, 슬래시 커맨드 한 번이면 끝.</p>
+
+  <div class="steps-list">
+    <div class="step-item">
+      <div class="step-num">1</div>
+      <div class="step-content">
+        <div class="step-title">스킬 설치</div>
+        <div class="step-desc">Clipwise 스킬을 <code>.claude/skills/</code> 디렉토리에 복사합니다. 프로젝트당 한 번(또는 글로벌) 실행.</div>
+        <div class="code-block">
+          <div class="code-header">bash</div>
+          <pre><code>npx clipwise install-skill</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">2</div>
+      <div class="step-content">
+        <div class="step-title">Claude Code에서 사용</div>
+        <div class="step-desc">Claude Code 세션에서 <code>/clipwise</code>를 입력하세요. 녹화할 내용을 자연어로 설명하면 됩니다.</div>
+        <div class="code-block">
+          <div class="code-header">Claude Code</div>
+          <pre><code>/clipwise
+> http://localhost:3000 대시보드 데모 녹화해줘
+  — 로그인 클릭, 이메일/비밀번호 입력, 분석 페이지 이동</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">3</div>
+      <div class="step-content">
+        <div class="step-title">나머지는 Claude가 처리</div>
+        <div class="step-desc">Claude가 YAML 시나리오를 생성하고, <code>npx clipwise validate</code>로 검증한 후, MP4를 녹화합니다 — 전부 자동.</div>
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top:20px;font-size:14px;color:var(--muted);">clipwise 업그레이드 후 <code>npx clipwise install-skill</code>을 다시 실행하면 최신 스킬로 업데이트됩니다.</p>
+</section>
+
+<!-- 이펙트 -->
+<section class="section" id="effects">
+  <div class="section-label">이펙트</div>
+  <h2 class="section-title">시네마틱 이펙트</h2>
+  <p class="section-sub">모든 이펙트는 선택사항이며 합리적인 기본값이 있습니다. 원하는 스타일로 조합하세요.</p>
+
+  <div class="effects-grid">
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>줌</div>
+      <div class="effect-desc">커서를 따라가며 클릭 대상에 자동으로 줌인합니다. 스마트 카메라: 스크롤 중 줌 자동 억제, 커서 위치 추적. 강도 프리셋(subtle → dramatic) 또는 숫자 스케일 설정.</div>
+      <span class="effect-tag">followCursor</span>
+      <span class="effect-tag">intensity</span>
+      <span class="effect-tag">smart camera</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>zoom:
+  enabled: true
+  intensity: light   # subtle|light|moderate|strong|dramatic
+  duration: 800</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>커서</div>
+      <div class="effect-desc">커스텀 커서 + 클릭 리플 + 트레일 + 하이라이트 + 속도 조절.</div>
+      <span class="effect-tag">trail</span>
+      <span class="effect-tag">highlight</span>
+      <span class="effect-tag">clickEffect</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>cursor:
+  enabled: true
+  speed: "normal"
+  trail: true
+  highlight: true</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>배경</div>
+      <div class="effect-desc">그라디언트/단색 패딩 + 라운드 코너 + 드롭 섀도.</div>
+      <span class="effect-tag">gradient</span>
+      <span class="effect-tag">shadow</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>background:
+  type: gradient
+  value: "linear-gradient(135deg,
+    #667eea 0%, #764ba2 100%)"
+  padding: 48
+  borderRadius: 14</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>디바이스 프레임</div>
+      <div class="effect-desc">브라우저, iPhone, iPad, Android 목업으로 녹화를 감쌉니다.</div>
+      <span class="effect-tag">browser</span>
+      <span class="effect-tag">iphone</span>
+      <span class="effect-tag">android</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>deviceFrame:
+  enabled: true
+  type: browser   # or iphone/ipad/android
+  darkMode: true</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>키스트로크 HUD</div>
+      <div class="effect-desc">타이핑 내용을 화면 하단에 실시간으로 표시합니다. 멀티세션: 각 입력 필드가 별도 줄로 표시 (최대 3줄, 오래된 줄은 흐리게). 기본은 단축키만 — <code>showTyping: true</code>로 일반 타이핑도 표시.</div>
+      <span class="effect-tag">bottom-center</span>
+      <span class="effect-tag">multi-session</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>keystroke:
+  enabled: true
+  showTyping: true   # 기본: false
+  position: bottom-center
+  fontSize: 16
+  fadeAfter: 1500</code></pre>
+      </div>
+    </div>
+
+    <div class="effect-card">
+      <div class="effect-title"><span class="effect-dot"></span>속도 램프</div>
+      <div class="effect-desc">클릭 근처 슬로우모션, 유휴 구간 자동 빨리감기.</div>
+      <span class="effect-tag">idleSpeed</span>
+      <span class="effect-tag">actionSpeed</span>
+      <div class="code-block" style="margin-top:10px;">
+        <pre><code>speedRamp:
+  enabled: true
+  idleSpeed: 3.0
+  actionSpeed: 0.8</code></pre>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -455,146 +595,6 @@ effects:
 # - 스마트 카메라: 스크롤 중 줌 억제; followCursor로 커서 추적
 # - 트랜지션: fade/blur는 시네마틱 컷, slide-left/up은 순차 흐름에 적합
 # - 오디오: MP4 포맷에서만 작동; 파일 경로가 유효해야 함</code></pre>
-  </div>
-</section>
-
-<!-- Claude Code 스킬 -->
-<section class="section" id="claude-code">
-  <div class="section-label">Claude Code</div>
-  <h2 class="section-title">AI 기반 워크플로</h2>
-  <p class="section-sub">내장된 <a href="https://claude.com/claude-code" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline;">Claude Code</a> 스킬을 설치하면 자연어로 시나리오를 생성할 수 있습니다. 설치 한 번, 슬래시 커맨드 한 번이면 끝.</p>
-
-  <div class="steps-list">
-    <div class="step-item">
-      <div class="step-num">1</div>
-      <div class="step-content">
-        <div class="step-title">스킬 설치</div>
-        <div class="step-desc">Clipwise 스킬을 <code>.claude/skills/</code> 디렉토리에 복사합니다. 프로젝트당 한 번(또는 글로벌) 실행.</div>
-        <div class="code-block">
-          <div class="code-header">bash</div>
-          <pre><code>npx clipwise install-skill</code></pre>
-        </div>
-      </div>
-    </div>
-
-    <div class="step-item">
-      <div class="step-num">2</div>
-      <div class="step-content">
-        <div class="step-title">Claude Code에서 사용</div>
-        <div class="step-desc">Claude Code 세션에서 <code>/clipwise</code>를 입력하세요. 녹화할 내용을 자연어로 설명하면 됩니다.</div>
-        <div class="code-block">
-          <div class="code-header">Claude Code</div>
-          <pre><code>/clipwise
-> http://localhost:3000 대시보드 데모 녹화해줘
-  — 로그인 클릭, 이메일/비밀번호 입력, 분석 페이지 이동</code></pre>
-        </div>
-      </div>
-    </div>
-
-    <div class="step-item">
-      <div class="step-num">3</div>
-      <div class="step-content">
-        <div class="step-title">나머지는 Claude가 처리</div>
-        <div class="step-desc">Claude가 YAML 시나리오를 생성하고, <code>npx clipwise validate</code>로 검증한 후, MP4를 녹화합니다 — 전부 자동.</div>
-      </div>
-    </div>
-  </div>
-
-  <p style="margin-top:20px;font-size:14px;color:var(--muted);">clipwise 업그레이드 후 <code>npx clipwise install-skill</code>을 다시 실행하면 최신 스킬로 업데이트됩니다.</p>
-</section>
-
-<!-- Effects -->
-<section class="section" id="effects">
-  <div class="section-label">이펙트</div>
-  <h2 class="section-title">시네마틱 이펙트</h2>
-  <p class="section-sub">모든 이펙트는 선택사항이며 합리적인 기본값이 있습니다. 원하는 스타일로 조합하세요.</p>
-
-  <div class="effects-grid">
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>줌</div>
-      <div class="effect-desc">커서를 따라가며 클릭 대상에 자동으로 줌인합니다. 스마트 카메라: 스크롤 중 줌 자동 억제, 커서 위치 추적. 강도 프리셋(subtle → dramatic) 또는 숫자 스케일 설정.</div>
-      <span class="effect-tag">followCursor</span>
-      <span class="effect-tag">intensity</span>
-      <span class="effect-tag">smart camera</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>zoom:
-  enabled: true
-  intensity: light   # subtle|light|moderate|strong|dramatic
-  duration: 800</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>커서</div>
-      <div class="effect-desc">커스텀 커서 + 클릭 리플 + 트레일 + 하이라이트 + 속도 조절.</div>
-      <span class="effect-tag">trail</span>
-      <span class="effect-tag">highlight</span>
-      <span class="effect-tag">clickEffect</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>cursor:
-  enabled: true
-  speed: "normal"
-  trail: true
-  highlight: true</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>배경</div>
-      <div class="effect-desc">그라디언트/단색 패딩 + 라운드 코너 + 드롭 섀도.</div>
-      <span class="effect-tag">gradient</span>
-      <span class="effect-tag">shadow</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>background:
-  type: gradient
-  value: "linear-gradient(135deg,
-    #667eea 0%, #764ba2 100%)"
-  padding: 48
-  borderRadius: 14</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>디바이스 프레임</div>
-      <div class="effect-desc">브라우저, iPhone, iPad, Android 목업으로 녹화를 감쌉니다.</div>
-      <span class="effect-tag">browser</span>
-      <span class="effect-tag">iphone</span>
-      <span class="effect-tag">android</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>deviceFrame:
-  enabled: true
-  type: browser   # or iphone/ipad/android
-  darkMode: true</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>키스트로크 HUD</div>
-      <div class="effect-desc">타이핑 내용을 화면 하단에 실시간으로 표시합니다. 멀티세션: 각 입력 필드가 별도 줄로 표시 (최대 3줄, 오래된 줄은 흐리게). 기본은 단축키만 — <code>showTyping: true</code>로 일반 타이핑도 표시.</div>
-      <span class="effect-tag">bottom-center</span>
-      <span class="effect-tag">multi-session</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>keystroke:
-  enabled: true
-  showTyping: true   # 기본: false
-  position: bottom-center
-  fontSize: 16
-  fadeAfter: 1500</code></pre>
-      </div>
-    </div>
-
-    <div class="effect-card">
-      <div class="effect-title"><span class="effect-dot"></span>속도 램프</div>
-      <div class="effect-desc">클릭 근처 슬로우모션, 유휴 구간 자동 빨리감기.</div>
-      <span class="effect-tag">idleSpeed</span>
-      <span class="effect-tag">actionSpeed</span>
-      <div class="code-block" style="margin-top:10px;">
-        <pre><code>speedRamp:
-  enabled: true
-  idleSpeed: 3.0
-  actionSpeed: 0.8</code></pre>
-      </div>
-    </div>
   </div>
 </section>
 

--- a/skills/clipwise.md
+++ b/skills/clipwise.md
@@ -64,7 +64,10 @@ steps: []                 # Array of steps (min 1, first must have navigate)
 - name: "Step name"           # Optional label
   captureDelay: 50            # ms to wait after actions before capturing (50-100 for snappy)
   holdDuration: 700           # ms to hold on result (500-800 for snappy)
-  transition: none            # none | fade
+  transition: none            # none | fade | slide-left | slide-up | blur
+  effects:                    # Per-step effects override (optional)
+    zoom:
+      enabled: false          # Disable zoom for this step only
   actions: []                 # Array of actions
 ```
 
@@ -168,16 +171,15 @@ steps: []                 # Array of steps (min 1, first must have navigate)
 
 ### Effects Configuration
 
-#### Zoom — Adaptive zoom follows cursor on clicks
+#### Zoom — Adaptive zoom follows cursor on clicks (smart camera: auto-suppressed during scroll)
 ```yaml
 zoom:
   enabled: true
-  intensity: moderate         # subtle(1.15x) | light(1.25x) | moderate(1.35x) | strong(1.5x) | dramatic(1.8x)
-  # scale: 1.35              # Or use numeric value (overridden by intensity)
-  duration: 500               # Zoom animation ms
-  easing: ease-in-out         # ease-in-out | ease-in | ease-out | linear
+  intensity: light            # subtle(1.15x) | light(1.25x) | moderate(1.35x) | strong(1.5x) | dramatic(1.8x)
+  # scale: 1.25              # Or use numeric value (overridden by intensity)
+  duration: 800               # Zoom animation ms
   autoZoom:
-    followCursor: true
+    followCursor: true        # Viewport pans to follow cursor position
     transitionDuration: 300
     padding: 200
 ```
@@ -188,7 +190,7 @@ cursor:
   enabled: true
   size: 20
   color: "#000000"
-  speed: fast                 # fast (~72ms) | normal (~144ms) | slow (~288ms)
+  speed: normal               # fast (~72ms) | normal (~144ms) | slow (~288ms)
   smoothing: true
   clickEffect: true
   clickColor: "rgba(59, 130, 246, 0.3)"
@@ -215,17 +217,16 @@ background:
 ```yaml
 deviceFrame:
   enabled: true
-  type: browser               # browser | macbook | iphone | ipad | android | none
+  type: browser               # browser | iphone | ipad | android | none
   darkMode: true
 ```
 
 | Type | Description |
 |------|-------------|
 | browser | macOS browser chrome with traffic lights |
-| macbook | MacBook Pro frame |
-| iphone | iPhone 15 Pro with Dynamic Island |
-| ipad | iPad Pro with camera dot |
-| android | Android with punch-hole camera |
+| iphone | iPhone 15 Pro with Dynamic Island + home bar |
+| ipad | iPad Pro with front camera dot |
+| android | Android generic with punch-hole camera |
 
 #### Keystroke HUD — Shows typed keys on screen
 ```yaml
@@ -260,6 +261,39 @@ speedRamp:
   transitionFrames: 15
 ```
 
+#### Audio Narration — Attach audio to MP4 output
+```yaml
+audio:
+  file: "./narration.mp3"     # MP3, WAV, etc.
+  volume: 1.0                 # 0.0 - 2.0 (default: 1.0)
+  fadeIn: 0                   # Fade-in duration in seconds
+  fadeOut: 0                  # Fade-out duration in seconds
+```
+
+### Per-Step Effects Override
+
+Override global effects on a per-step basis. Unset properties inherit from global config.
+
+```yaml
+effects:
+  zoom:
+    enabled: true
+    intensity: light
+
+steps:
+  - name: "Overview"
+    effects:
+      zoom:
+        enabled: false        # No zoom for this step
+    actions: [...]
+
+  - name: "Detail view"
+    effects:
+      zoom:
+        intensity: strong     # Extra zoom for this step only
+    actions: [...]
+```
+
 ### Output Presets
 
 | Preset | Use case | Approx size (30s) |
@@ -277,6 +311,10 @@ speedRamp:
 5. **Prefer async waits over fixed `wait`**: use `waitForSelector`, `waitForFunction`, `waitForResponse` instead of guessing durations
 6. **Viewport = output**: if viewport and output dimensions differ, output will be scaled (a warning is shown)
 7. **Mobile scenarios**: use `viewport: {width: 390, height: 844}` with `deviceFrame.type: iphone` and `output: {width: 540, height: 1080}`
+8. **Per-step effects**: any effect property can be overridden per step — unset properties inherit from global config
+9. **Smart camera**: zoom is automatically suppressed during scroll actions; `followCursor` pans to cursor position
+10. **Transitions**: use `fade` or `blur` for cinematic cuts between major sections; `slide-left`/`slide-up` for sequential flows
+11. **Audio**: audio file must exist at the specified path; only works with MP4 output format
 
 ## Timing Presets
 


### PR DESCRIPTION
## Summary

- Update AI schema reference `v0.5.0` → `v0.6.0` in EN/KO static pages and skill file
- Add missing v0.6.0 features: new transitions (`slide-left`, `slide-up`, `blur`), audio narration, per-step effects override, smart camera
- Fix outdated defaults: `light` zoom (was `moderate`), `normal` cursor speed (was `fast`), updated background/cursor defaults
- Fix KO zoom card using deprecated `scale: 1.8` → `intensity: light`
- Add `showTyping` + `multi-session` tags to KO keystroke HUD card (EN parity)
- Remove `macbook` device type from skill file (not in README/codebase)
- Add 4 new critical rules to skill file (#8–#11)

## Test plan

- [x] All 76 existing tests pass
- [ ] Verify EN static page renders correctly at `/docs/index.html`
- [ ] Verify KO static page renders correctly at `/docs/ko/index.html`
- [ ] Verify "Copy entire schema" button copies v0.6.0 schema
- [ ] Verify `/clipwise` skill in Claude Code picks up new transitions and audio


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #7